### PR TITLE
A lot of Flow typing improvements

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,6 +3,7 @@
 [include]
 
 [libs]
+/flow-typed
 
 [lints]
 

--- a/flow-typed/npm/uuid_v3.x.x.js
+++ b/flow-typed/npm/uuid_v3.x.x.js
@@ -1,0 +1,102 @@
+// flow-typed signature: 3cf668e64747095cab0bb360cf2fb34f
+// flow-typed version: d659bd0cb8/uuid_v3.x.x/flow_>=v0.32.x
+
+declare module 'uuid' {
+  declare class uuid {
+    static (
+      options?: {|
+        random?: number[],
+        rng?: () => number[] | Buffer,
+      |},
+      buffer?: number[] | Buffer,
+      offset?: number,
+    ): string;
+
+    static v1(
+      options?: {|
+        node?: number[],
+        clockseq?: number,
+        msecs?: number | Date,
+        nsecs?: number,
+      |},
+      buffer?: number[] | Buffer,
+      offset?: number,
+    ): string;
+
+    static v4(
+      options?: {|
+        random?: number[],
+        rng?: () => number[] | Buffer,
+      |},
+      buffer?: number[] | Buffer,
+      offset?: number,
+    ): string;
+  }
+  declare module.exports: Class<uuid>;
+}
+
+declare module 'uuid/v1' {
+  declare class v1 {
+    static (
+      options?: {|
+        node?: number[],
+        clockseq?: number,
+        msecs?: number | Date,
+        nsecs?: number,
+      |},
+      buffer?: number[] | Buffer,
+      offset?: number,
+    ): string;
+  }
+
+  declare module.exports: Class<v1>;
+}
+
+declare module 'uuid/v3' {
+  declare class v3 {
+    static (
+      name?: string | number[],
+      namespace?: string | number[],
+      buffer?: number[] | Buffer,
+      offset?: number,
+    ): string;
+
+    static name: string;
+    static DNS: string;
+    static URL: string;
+  }
+
+  declare module.exports: Class<v3>;
+}
+
+declare module 'uuid/v4' {
+  declare class v4 {
+    static (
+      options?: {|
+        random?: number[],
+        rng?: () => number[] | Buffer,
+      |},
+      buffer?: number[] | Buffer,
+      offset?: number,
+    ): string;
+  }
+
+  declare module.exports: Class<v4>;
+}
+
+declare module 'uuid/v5' {
+  declare class v5 {
+    static (
+      name?: string | number[],
+      namespace?: string | number[],
+      buffer?: number[] | Buffer,
+      offset?: number,
+    ): string;
+
+    static name: string;
+    static DNS: string;
+    static URL: string;
+  }
+
+  declare module.exports: Class<v5>;
+}

--- a/src/api/ActiveBridge.js
+++ b/src/api/ActiveBridge.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import HueBridge from './HueBridge';
 import Storage from './Storage';

--- a/src/api/HueBridgeList.js
+++ b/src/api/HueBridgeList.js
@@ -1,3 +1,5 @@
+// @flow strict
+
 import ActiveBridge from './ActiveBridge';
 import HueBridge from './HueBridge';
 import Storage from './Storage';
@@ -8,20 +10,20 @@ const storage = new Storage(STORAGE_NAME, STORAGE_VERSION);
 
 const NUPNP_URL = 'https://www.meethue.com/api/nupnp';
 
-function readStoredBridges() {
+function readStoredBridges(): Array<HueBridge> {
   const bridgeIds = storage.read() || [];
   return bridgeIds.map((id) => {
     return new HueBridge(id);
   });
 }
 
-function addBridge(bridgeId) {
+function addBridge(bridgeId: string): void {
   const bridgeIds = storage.read() || [];
   bridgeIds.push(bridgeId);
   storage.write(bridgeIds);
 }
 
-async function discoverLocalBridges() {
+async function discoverLocalBridges(): Promise<Array<HueBridge>> {
   const response = await fetch(NUPNP_URL);
   const json = await response.json();
   return json.map((item) => {
@@ -34,7 +36,7 @@ async function discoverLocalBridges() {
   });
 }
 
-function loadBridges() {
+function loadBridges(): Array<string> {
   const storedBridges = readStoredBridges();
   ActiveBridge.restore();
   const storedBridgeIds = storedBridges.map((bridge) => {
@@ -43,18 +45,20 @@ function loadBridges() {
   return storedBridgeIds;
 }
 
-async function fetchBridges() {
+async function fetchBridges(): Promise<Array<string>> {
   const storedBridges = readStoredBridges();
   const localBridges = await discoverLocalBridges();
 
   const storedBridgeIds = storedBridges.map((bridge) => {
     return bridge.id;
   });
-  const localBridgesIds = localBridges.map((bridge) => {
+  const localBridgeIds = localBridges.map((bridge) => {
     return bridge.id;
   });
-  const allBridgeIds = new Set(storedBridgeIds.concat(localBridgesIds));
-  storage.write(Array.from(allBridgeIds));
+  const allBridgeIds = Array.from(
+    new Set([...storedBridgeIds, ...localBridgeIds]),
+  );
+  storage.write(allBridgeIds);
   ActiveBridge.restore();
   return allBridgeIds;
 }

--- a/src/api/Settings.js
+++ b/src/api/Settings.js
@@ -2,11 +2,29 @@
 
 import Storage from './Storage';
 
+type SettingsType = {
+  // OAuth settings
+  appId?: string,
+  clientId?: string,
+  clientSecret?: string,
+
+  // OAuth tokens
+  tokenType?: string,
+  refreshToken?: string,
+  refreshTokenExpiresAt?: number,
+  accessToken?: string,
+  accessTokenExpiresAt?: number,
+
+  // Console last state
+  lastConsoleMethod?: string,
+  lastConsolePath?: string,
+};
+
 const STORAGE_NAME = 'settings';
 const STORAGE_VERSION = 1;
 const storage = new Storage(STORAGE_NAME, STORAGE_VERSION);
 
-function read(): {} {
+function read(): SettingsType {
   const settings = storage.read();
   if (typeof settings === 'object' && settings !== null) {
     return settings;
@@ -15,7 +33,7 @@ function read(): {} {
   }
 }
 
-function write(settings: {}) {
+function write(settings: SettingsType) {
   storage.write(settings);
 }
 

--- a/src/api/Storage.js
+++ b/src/api/Storage.js
@@ -26,7 +26,7 @@ function remove(key: string) {
   }
 }
 
-class Storage {
+class Storage<T> {
   name: string;
   version: number;
 
@@ -41,11 +41,11 @@ class Storage {
     }
   }
 
-  read(): mixed {
+  read(): ?T {
     const key = `${this.name}:${this.version}`;
     const jsonString = get(key);
 
-    let value = null;
+    let value: ?T = null;
     if (jsonString) {
       try {
         value = JSON.parse(jsonString);
@@ -58,7 +58,7 @@ class Storage {
     return value;
   }
 
-  write(value: mixed) {
+  write(value: T) {
     const key = `${this.name}:${this.version}`;
     const jsonString = JSON.stringify(value);
     set(key, jsonString);

--- a/src/api/deviceId.js
+++ b/src/api/deviceId.js
@@ -1,3 +1,5 @@
+// @flow strict
+
 import uuid from 'uuid';
 import Storage from './Storage';
 
@@ -5,10 +7,10 @@ const STORAGE_NAME = 'device_id';
 const STORAGE_VERSION = 1;
 const storage = new Storage(STORAGE_NAME, STORAGE_VERSION);
 
-const deviceId = function() {
-  const existingID = storage.read();
+const deviceId = function(): string {
+  const existingID = String(storage.read());
   if (!existingID) {
-    const newID = uuid();
+    const newID: string = uuid();
     storage.write(newID);
     return newID;
   }

--- a/src/ui/HueBridgeSelector.js
+++ b/src/ui/HueBridgeSelector.js
@@ -33,7 +33,7 @@ class HueBridgeSelector extends Component {
 
   updateBridgeList() {
     HueBridgeList.fetch().then((bridgeIds) => {
-      const bridges = Array.from(bridgeIds).map((id) => {
+      const bridges = bridgeIds.map((id) => {
         return HueBridge.getById(id);
       });
       this.setState({

--- a/src/ui/SettingsView.js
+++ b/src/ui/SettingsView.js
@@ -1,17 +1,43 @@
+// @flow strict
+
 import Settings from '../api/Settings';
+import Storage from '../api/Storage';
 import React, { Component } from 'react';
 
-class SettingsView extends Component {
-  constructor(props) {
+type PropsType = {
+  match: {
+    params: {
+      dialog: string,
+    },
+  },
+};
+
+type StateType = {
+  appId: ?string,
+  clientId: ?string,
+  clientSecret: ?string,
+};
+
+class SettingsView extends Component<PropsType, StateType> {
+  appIdInput: ?HTMLInputElement;
+  clientIdInput: ?HTMLInputElement;
+  clientSecretInput: ?HTMLInputElement;
+
+  constructor(props: PropsType) {
     super(props);
-    this.state = Settings.read();
+    this.state = {
+      appId: null,
+      clientId: null,
+      clientSecret: null,
+      ...Settings.read(),
+    };
   }
 
   onSaveClick() {
     const settings = {
-      appId: this.appIdInput.value,
-      clientId: this.clientIdInput.value,
-      clientSecret: this.clientSecretInput.value,
+      appId: this.appIdInput && this.appIdInput.value,
+      clientId: this.clientIdInput && this.clientIdInput.value,
+      clientSecret: this.clientSecretInput && this.clientSecretInput.value,
     };
     Settings.write(settings);
     this.setState(settings);

--- a/src/ui/SettingsView.js
+++ b/src/ui/SettingsView.js
@@ -13,9 +13,9 @@ type PropsType = {
 };
 
 type StateType = {
-  appId: ?string,
-  clientId: ?string,
-  clientSecret: ?string,
+  appId?: string,
+  clientId?: string,
+  clientSecret?: string,
 };
 
 class SettingsView extends Component<PropsType, StateType> {
@@ -25,22 +25,27 @@ class SettingsView extends Component<PropsType, StateType> {
 
   constructor(props: PropsType) {
     super(props);
-    this.state = {
-      appId: null,
-      clientId: null,
-      clientSecret: null,
-      ...Settings.read(),
-    };
+    this.state = Settings.read();
   }
 
   onSaveClick() {
+    const appId = (this.appIdInput && this.appIdInput.value) || '';
+    const clientId = (this.clientIdInput && this.clientIdInput.value) || '';
+    const clientSecret =
+      (this.clientSecretInput && this.clientSecretInput.value) || '';
+
     const settings = {
-      appId: this.appIdInput && this.appIdInput.value,
-      clientId: this.clientIdInput && this.clientIdInput.value,
-      clientSecret: this.clientSecretInput && this.clientSecretInput.value,
+      ...Settings.read(),
+      appId,
+      clientId,
+      clientSecret,
     };
     Settings.write(settings);
-    this.setState(settings);
+    this.setState({
+      appId,
+      clientId,
+      clientSecret,
+    });
   }
 
   onResetClick() {


### PR DESCRIPTION
Because `deviceId` depends on `uuid` module, which doesn't have Flow typing, I have to use [flow-typed](https://github.com/flowtype/flow-typed/) to import typing information to `./flow-typed`. I added `./flow-typed` to `.flowconfig` for this purpose.

`flow-typed/npm/uuid_v3.x.x.js` is external imported code. Ideally, this file is only added automatically at development time and test time. It shouldn't be included in the repo. It shouldn't exist in production build. I don't know a way to do that, so I'm including it in the code for now.

In order to introduce stronger typing information for `SettingsView`, I need to make the data read from `Settings` stronger typed. However, `Storage` uses `JSON.parse` and doesn't provide strong type. To solve this problem, I need to give a strong type to the value returned from `JSON.parse`. That type is passed to `Storage` as the `T` in `Storage<T>` generic.