### PR TITLE
Created special view for entertainment area group type

### DIFF
--- a/src/ui/Group.css
+++ b/src/ui/Group.css
@@ -1,0 +1,18 @@
+.groupSquare::before {
+  content: '';
+  display: block;
+  padding-top: 100%;
+}
+
+.groupSquare {
+  background-color: #000000;
+  position: relative;
+}
+
+.groupSquare > .groupEntertainmentArea {
+  bottom: 5%;
+  left: 5%;
+  position: absolute;
+  right: 5%;
+  top: 5%;
+}

--- a/src/ui/Group.js
+++ b/src/ui/Group.js
@@ -1,30 +1,65 @@
 import Light from './Light';
 import React, { Component } from 'react';
+import './Group.css';
 
 class Group extends Component {
   render() {
     const json = this.props.json;
-    return (
-      <div className="card">
-        <div className="card-header">{json.name}</div>
-        <ul className="list-group list-group-flush">
-          {json.lights.map((key) => {
-            return (
-              <Light
-                rendering="item"
-                json={this.props.lights[key]}
-                lightId={key}
-                key={key}
-              />
-            );
-          })}
-        </ul>
-        <div className="card-footer text-muted">
-          {json.type}
-          {typeof json.class === 'string' ? `: ${json.class}` : ''}
-        </div>
-      </div>
-    );
+    switch (json.type) {
+      case 'Entertainment':
+        return (
+          <div className="card">
+            <div className="card-header">{json.name}</div>
+            <div className="groupSquare">
+              <div className="groupEntertainmentArea">
+                {json.lights.map((key) => {
+                  const locations = json.locations[key];
+                  const left = (locations[0] + 1) / 2;
+                  const bottom = (locations[1] + 1) / 2;
+                  return (
+                    <Light
+                      rendering="circle"
+                      locations={{
+                        left: left * 100 + '%',
+                        bottom: bottom * 100 + '%',
+                      }}
+                      json={this.props.lights[key]}
+                      lightId={key}
+                      key={key}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+            <div className="card-footer text-muted">
+              {json.type}
+              {typeof json.class === 'string' ? `: ${json.class}` : ''}
+            </div>
+          </div>
+        );
+      default:
+        return (
+          <div className="card">
+            <div className="card-header">{json.name}</div>
+            <ul className="list-group list-group-flush">
+              {json.lights.map((key) => {
+                return (
+                  <Light
+                    rendering="item"
+                    json={this.props.lights[key]}
+                    lightId={key}
+                    key={key}
+                  />
+                );
+              })}
+            </ul>
+            <div className="card-footer text-muted">
+              {json.type}
+              {typeof json.class === 'string' ? `: ${json.class}` : ''}
+            </div>
+          </div>
+        );
+    }
   }
 }
 

--- a/src/ui/Light.css
+++ b/src/ui/Light.css
@@ -1,0 +1,23 @@
+.light {
+  position: absolute;
+  width: 10%;
+}
+
+.lightSquare::before {
+  content: '';
+  display: block;
+  padding-top: 100%;
+}
+
+.lightSquare {
+  position: relative;
+}
+
+.lightSquare > .lightCircle {
+  border-radius: 50%;
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}

--- a/src/ui/Light.js
+++ b/src/ui/Light.js
@@ -1,6 +1,7 @@
 import JsonEditor from './json/JsonEditor';
 import HueColor from '../api/HueColor';
 import React, { Component } from 'react';
+import './Light.css';
 
 class Light extends Component {
   render() {
@@ -74,6 +75,22 @@ class Light extends Component {
           >
             {json.name}
           </li>
+        );
+      case 'circle':
+        return (
+          <div className="light" style={this.props.locations}>
+            <div className="lightSquare">
+              <div
+                className="lightCircle"
+                style={{
+                  backgroundColor: hex,
+                  backgroundImage: `radial-gradient(circle, ${hex} 0%, ${hex} ${brightness *
+                    100}%, black ${brightness * 100}%, ${hex} 100%)`,
+                  color: fontColor,
+                }}
+              />
+            </div>
+          </div>
         );
       default:
         return <JsonEditor json={json} />;


### PR DESCRIPTION
Before:

<img width="602" alt="screenshot 2018-05-19 22 23 00" src="https://user-images.githubusercontent.com/112175/40275980-370396a4-5bb3-11e8-8593-46641696d680.png">

After:

<img width="602" alt="screenshot 2018-05-19 22 18 37" src="https://user-images.githubusercontent.com/112175/40275972-1775ac28-5bb3-11e8-97d6-d8d6fdcb5d17.png">

Entertainment group has special `locations` definition. It determines where each light is within a 3D space. (I'm rendering only 2D so far.) See official document here:

https://developers.meethue.com/documentation/groups-api