### PR TITLE
Introduced loading animation when fetching from network

### DIFF
--- a/src/ui/CenterCard.js
+++ b/src/ui/CenterCard.js
@@ -1,0 +1,18 @@
+// @flow strict
+
+import * as React from 'react';
+import { Component } from 'react';
+
+class CenterCard extends Component<{ children?: React.Node }> {
+  render() {
+    return (
+      <div className="row justify-content-md-center">
+        <div className="col col-md-6 col-lg-4">
+          <div className="card my-3">{this.props.children}</div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default CenterCard;

--- a/src/ui/ConsoleView.js
+++ b/src/ui/ConsoleView.js
@@ -21,8 +21,7 @@ type StateType = {
   path: string,
   body: ?string,
   json: ?{},
-  loading: boolean,
-  loaded: boolean,
+  network: null | 'loading' | 'loaded',
 };
 
 class ConsoleView extends Component<PropsType, StateType> {
@@ -35,8 +34,7 @@ class ConsoleView extends Component<PropsType, StateType> {
       path: settings.lastConsolePath || '/config',
       body: null,
       json: null,
-      loading: false,
-      loaded: false,
+      network: null,
     };
   }
 
@@ -88,7 +86,7 @@ class ConsoleView extends Component<PropsType, StateType> {
     const bridge = this.state.bridge;
     if (bridge) {
       this.setState({
-        loading: true,
+        network: 'loading',
       });
       bridge
         .fetch(this.state.path, {
@@ -99,8 +97,7 @@ class ConsoleView extends Component<PropsType, StateType> {
           console.log(json);
           this.setState({
             json,
-            loading: false,
-            loaded: true,
+            network: 'loaded',
           });
         });
     }
@@ -119,7 +116,7 @@ class ConsoleView extends Component<PropsType, StateType> {
         <div className="card my-3">
           <div className="card-body">
             <div className="form-inline">
-              <div className="input-group mb-2 mr-sm-2 flex-fill">
+              <div className="input-group mb-2 mb-sm-0 mr-sm-2 flex-fill">
                 <div className="input-group-prepend">
                   <button
                     id="method"
@@ -183,8 +180,8 @@ class ConsoleView extends Component<PropsType, StateType> {
                 />
               </div>
               <button
-                className="btn btn-primary mb-2"
-                disabled={this.state.loading}
+                className="btn btn-primary"
+                disabled={this.state.network === 'loading'}
                 onClick={this.onSendClick.bind(this)}
               >
                 Send
@@ -209,11 +206,15 @@ class ConsoleView extends Component<PropsType, StateType> {
         <div className="card my-3">
           <div className="card-header">Response</div>
           <div className="card-body">
-            {this.state.loading ? (
+            {this.state.network === 'loading' ? (
               <LoadingIndicator />
-            ) : this.state.loaded ? (
+            ) : this.state.network === 'loaded' ? (
               <JsonEditor json={this.state.json} />
-            ) : null}
+            ) : (
+              <div className="alert alert-info mb-0" role="alert">
+                Send a request to see the response.
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/ui/ConsoleView.js
+++ b/src/ui/ConsoleView.js
@@ -1,6 +1,7 @@
 // @flow strict
 
 import JsonEditor from './json/JsonEditor';
+import LoadingIndicator from './LoadingIndicator';
 import HueBridge from '../api/HueBridge';
 import HueBridgeList from '../api/HueBridgeList';
 import Settings from '../api/Settings';
@@ -20,6 +21,8 @@ type StateType = {
   path: string,
   body: ?string,
   json: ?{},
+  loading: boolean,
+  loaded: boolean,
 };
 
 class ConsoleView extends Component<PropsType, StateType> {
@@ -32,6 +35,8 @@ class ConsoleView extends Component<PropsType, StateType> {
       path: settings.lastConsolePath || '/config',
       body: null,
       json: null,
+      loading: false,
+      loaded: false,
     };
   }
 
@@ -80,8 +85,12 @@ class ConsoleView extends Component<PropsType, StateType> {
   }
 
   onSendClick() {
-    if (this.state.bridge) {
-      this.state.bridge
+    const bridge = this.state.bridge;
+    if (bridge) {
+      this.setState({
+        loading: true,
+      });
+      bridge
         .fetch(this.state.path, {
           method: this.state.method.toUpperCase(),
           body: this.state.body,
@@ -90,6 +99,8 @@ class ConsoleView extends Component<PropsType, StateType> {
           console.log(json);
           this.setState({
             json,
+            loading: false,
+            loaded: true,
           });
         });
     }
@@ -173,6 +184,7 @@ class ConsoleView extends Component<PropsType, StateType> {
               </div>
               <button
                 className="btn btn-primary mb-2"
+                disabled={this.state.loading}
                 onClick={this.onSendClick.bind(this)}
               >
                 Send
@@ -197,7 +209,11 @@ class ConsoleView extends Component<PropsType, StateType> {
         <div className="card my-3">
           <div className="card-header">Response</div>
           <div className="card-body">
-            <JsonEditor json={this.state.json} />
+            {this.state.loading ? (
+              <LoadingIndicator />
+            ) : this.state.loaded ? (
+              <JsonEditor json={this.state.json} />
+            ) : null}
           </div>
         </div>
       </div>

--- a/src/ui/ConsoleView.js
+++ b/src/ui/ConsoleView.js
@@ -21,7 +21,7 @@ type StateType = {
   path: string,
   body: ?string,
   json: ?{},
-  network: null | 'loading' | 'loaded',
+  network: 'unsent' | 'loading' | 'done',
 };
 
 class ConsoleView extends Component<PropsType, StateType> {
@@ -34,7 +34,7 @@ class ConsoleView extends Component<PropsType, StateType> {
       path: settings.lastConsolePath || '/config',
       body: null,
       json: null,
-      network: null,
+      network: 'unsent',
     };
   }
 
@@ -97,7 +97,7 @@ class ConsoleView extends Component<PropsType, StateType> {
           console.log(json);
           this.setState({
             json,
-            network: 'loaded',
+            network: 'done',
           });
         });
     }
@@ -208,7 +208,7 @@ class ConsoleView extends Component<PropsType, StateType> {
           <div className="card-body">
             {this.state.network === 'loading' ? (
               <LoadingIndicator />
-            ) : this.state.network === 'loaded' ? (
+            ) : this.state.network === 'done' ? (
               <JsonEditor json={this.state.json} />
             ) : (
               <div className="alert alert-info mb-0" role="alert">

--- a/src/ui/GroupsView.js
+++ b/src/ui/GroupsView.js
@@ -1,4 +1,6 @@
+import CenterCard from './CenterCard';
 import Group from './Group';
+import LoadingIndicator from './LoadingIndicator';
 import HueBridge from '../api/HueBridge';
 import HueBridgeList from '../api/HueBridgeList';
 import React, { Component } from 'react';
@@ -9,6 +11,7 @@ class GroupsView extends Component {
     this.state = {
       bridge: null,
       json: null,
+      loading: false,
     };
   }
 
@@ -35,6 +38,7 @@ class GroupsView extends Component {
     const bridge = this.getActiveBridge();
     this.setState({
       bridge,
+      loading: true,
     });
     Promise.all([bridge.fetch('/groups'), bridge.fetch('/lights')]).then(
       (results) => {
@@ -43,6 +47,7 @@ class GroupsView extends Component {
         this.setState({
           json,
           lights,
+          loading: false,
         });
       },
       () => {},
@@ -50,22 +55,40 @@ class GroupsView extends Component {
   }
 
   render() {
-    return (
-      <div className="card-columns my-3">
-        {this.state.json === null
-          ? 'No groups'
-          : Object.keys(this.state.json).map((key) => {
-              return (
-                <Group
-                  json={this.state.json[key]}
-                  groupId={key}
-                  lights={this.state.lights}
-                  key={key}
-                />
-              );
-            })}
-      </div>
-    );
+    if (this.state.loading) {
+      return (
+        <CenterCard>
+          <h5 className="card-header">Loading...</h5>
+          <div className="card-body">
+            <LoadingIndicator />
+          </div>
+        </CenterCard>
+      );
+    } else if (
+      this.state.json === null ||
+      Object.keys(this.state.json).length === 0
+    ) {
+      return (
+        <div className="alert alert-info my-3" role="alert">
+          No groups.
+        </div>
+      );
+    } else {
+      return (
+        <div className="card-columns my-3">
+          {Object.keys(this.state.json).map((key) => {
+            return (
+              <Group
+                json={this.state.json[key]}
+                groupId={key}
+                lights={this.state.lights}
+                key={key}
+              />
+            );
+          })}
+        </div>
+      );
+    }
   }
 }
 

--- a/src/ui/LightsView.js
+++ b/src/ui/LightsView.js
@@ -1,3 +1,5 @@
+import CenterCard from './CenterCard';
+import LoadingIndicator from './LoadingIndicator';
 import Light from './Light';
 import HueBridge from '../api/HueBridge';
 import HueBridgeList from '../api/HueBridgeList';
@@ -9,6 +11,7 @@ class LightsView extends Component {
     this.state = {
       bridge: null,
       json: null,
+      loading: false,
     };
   }
 
@@ -35,32 +38,52 @@ class LightsView extends Component {
     const bridge = this.getActiveBridge();
     this.setState({
       bridge,
+      loading: true,
     });
     bridge.fetch('/lights').then((json) => {
       console.log(json);
       this.setState({
         json,
+        loading: false,
       });
     });
   }
 
   render() {
-    return (
-      <div className="card-columns my-3">
-        {this.state.json === null
-          ? 'No lights'
-          : Object.keys(this.state.json).map((key) => {
-              return (
-                <Light
-                  rendering="card"
-                  json={this.state.json[key]}
-                  lightId={key}
-                  key={key}
-                />
-              );
-            })}
-      </div>
-    );
+    if (this.state.loading) {
+      return (
+        <CenterCard>
+          <h5 className="card-header">Loading...</h5>
+          <div className="card-body">
+            <LoadingIndicator />
+          </div>
+        </CenterCard>
+      );
+    } else if (
+      this.state.json === null ||
+      Object.keys(this.state.json).length === 0
+    ) {
+      return (
+        <div className="alert alert-info my-3" role="alert">
+          No lights.
+        </div>
+      );
+    } else {
+      return (
+        <div className="card-columns my-3">
+          {Object.keys(this.state.json).map((key) => {
+            return (
+              <Light
+                rendering="card"
+                json={this.state.json[key]}
+                lightId={key}
+                key={key}
+              />
+            );
+          })}
+        </div>
+      );
+    }
   }
 }
 

--- a/src/ui/LoadingIndicator.js
+++ b/src/ui/LoadingIndicator.js
@@ -1,0 +1,22 @@
+// @flow strict
+
+import React, { Component } from 'react';
+
+class LoadingIndicator extends Component<{}> {
+  render() {
+    return (
+      <div className="progress">
+        <div
+          className="progress-bar progress-bar-striped progress-bar-animated"
+          role="progressbar"
+          aria-valuenow="100"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          style={{ width: '100%' }}
+        />
+      </div>
+    );
+  }
+}
+
+export default LoadingIndicator;

--- a/src/ui/SettingsView.js
+++ b/src/ui/SettingsView.js
@@ -1,5 +1,6 @@
 // @flow strict
 
+import CenterCard from './CenterCard';
 import Settings from '../api/Settings';
 import Storage from '../api/Storage';
 import React, { Component } from 'react';
@@ -139,13 +140,7 @@ class SettingsView extends Component<PropsType, StateType> {
       default:
         throw new Error(`Unsupported settings dialog: ${dialog}`);
     }
-    return (
-      <div className="row justify-content-md-center">
-        <div className="col col-md-6 col-lg-4">
-          <div className="card my-3">{dialogBody}</div>
-        </div>
-      </div>
-    );
+    return <CenterCard>{dialogBody}</CenterCard>;
   }
 }
 


### PR DESCRIPTION
Sometimes it's hard to tell whether the app is broken or it's waiting for the response, so I added loading indicator to show this.

The loading indicator would show up in lights view and groups view:

<img width="1792" alt="screenshot 2018-06-16 17 48 51" src="https://user-images.githubusercontent.com/112175/41503639-a044be0a-718d-11e8-906e-f60e33e2fc9d.png">

It would also show up in console view when fetching:

<img width="1792" alt="screenshot 2018-06-16 17 49 03" src="https://user-images.githubusercontent.com/112175/41503642-aa08ed80-718d-11e8-9437-8c5642847233.png">
