### PR TITLE
Made JSON copiable text

### DIFF
--- a/src/ui/json/JsonArray.js
+++ b/src/ui/json/JsonArray.js
@@ -8,40 +8,72 @@ import JsonBoolean from './JsonBoolean';
 import JsonNull from './JsonNull';
 
 class JsonArray extends Component<{
-  name: ?string,
+  depth: number,
   json: Array<mixed>,
 }> {
   static defaultProps = {
-    name: null,
+    depth: 0,
     json: [],
   };
 
   render() {
-    return (
-      <div className="jsonArray">
-        {this.props.name ? `"${this.props.name}": ` : ''}
-        {'['}
-        {this.props.json.map((value, index) => {
-          switch (typeof value) {
-            case 'object':
-              if (value === null) {
-                return <JsonNull key={index} />;
-              } else if (Array.isArray(value)) {
-                return <JsonArray json={value} key={index} />;
-              }
-              return <JsonObject json={value} key={index} />;
-            case 'number':
-              return <JsonNumber json={value} key={index} />;
-            case 'string':
-              return <JsonString json={value} key={index} />;
-            case 'boolean':
-              return <JsonBoolean json={value} key={index} />;
-            default:
-              throw new Error('Invalid json property');
-          }
+    const currentIndentation = (
+      <React.Fragment>
+        {Array.from(new Array(this.props.depth).keys()).map((_) => {
+          return <React.Fragment>&nbsp; </React.Fragment>;
         })}
+      </React.Fragment>
+    );
+    const nextIndentation = (
+      <React.Fragment>&nbsp; {currentIndentation}</React.Fragment>
+    );
+    return (
+      <span className="jsonArray">
+        {'['}
+        {this.props.json.length === 0 ? null : (
+          <ul>
+            {this.props.json.map((value, index) => {
+              let jsonContent;
+              switch (typeof value) {
+                case 'object':
+                  if (value === null) {
+                    jsonContent = <JsonNull />;
+                    break;
+                  } else if (Array.isArray(value)) {
+                    jsonContent = (
+                      <JsonArray json={value} depth={this.props.depth + 1} />
+                    );
+                    break;
+                  }
+                  jsonContent = (
+                    <JsonObject json={value} depth={this.props.depth + 1} />
+                  );
+                  break;
+                case 'number':
+                  jsonContent = <JsonNumber json={value} />;
+                  break;
+                case 'string':
+                  jsonContent = <JsonString json={value} />;
+                  break;
+                case 'boolean':
+                  jsonContent = <JsonBoolean json={value} />;
+                  break;
+                default:
+                  throw new Error('Invalid json property');
+              }
+              return (
+                <li key={index}>
+                  {nextIndentation}
+                  {jsonContent}
+                  {','}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        {currentIndentation}
         {']'}
-      </div>
+      </span>
     );
   }
 }

--- a/src/ui/json/JsonBoolean.js
+++ b/src/ui/json/JsonBoolean.js
@@ -3,21 +3,14 @@
 import React, { Component } from 'react';
 
 class JsonBoolean extends Component<{
-  name: ?string,
   json: boolean,
 }> {
   static defaultProps = {
-    name: null,
     json: false,
   };
 
   render() {
-    return (
-      <div>
-        {this.props.name ? `"${this.props.name}": ` : ''}
-        {this.props.json.toString()}
-      </div>
-    );
+    return <span>{this.props.json.toString()}</span>;
   }
 }
 

--- a/src/ui/json/JsonEditor.css
+++ b/src/ui/json/JsonEditor.css
@@ -1,9 +1,6 @@
-.jsonObject > *,
-.jsonArray > * {
-  padding-left: 20px;
-}
-
-.jsonObject > *::after,
-.jsonArray > *::after {
-  content: ",";
+.jsonObject > ul,
+.jsonArray > ul {
+  list-style-type: none;
+  margin-bottom: 0;
+  padding-left: 0;
 }

--- a/src/ui/json/JsonEditor.js
+++ b/src/ui/json/JsonEditor.js
@@ -18,23 +18,31 @@ class JsonEditor extends Component<{
 
   render() {
     const json = this.props.json;
+    let jsonContent;
     switch (typeof json) {
       case 'object':
         if (json === null) {
-          return <JsonNull />;
+          jsonContent = <JsonNull />;
+          break;
         } else if (Array.isArray(json)) {
-          return <JsonArray json={json} />;
+          jsonContent = <JsonArray json={json} />;
+          break;
         }
-        return <JsonObject json={json} />;
+        jsonContent = <JsonObject json={json} />;
+        break;
       case 'number':
-        return <JsonNumber json={json} />;
+        jsonContent = <JsonNumber json={json} />;
+        break;
       case 'string':
-        return <JsonString json={json} />;
+        jsonContent = <JsonString json={json} />;
+        break;
       case 'boolean':
-        return <JsonBoolean json={json} />;
+        jsonContent = <JsonBoolean json={json} />;
+        break;
       default:
         throw new Error('Invalid json property');
     }
+    return <div className="text-monospace">{jsonContent}</div>;
   }
 }
 

--- a/src/ui/json/JsonNull.js
+++ b/src/ui/json/JsonNull.js
@@ -2,20 +2,11 @@
 
 import React, { Component } from 'react';
 
-class JsonNull extends Component<{
-  name: ?string,
-}> {
-  static defaultProps = {
-    name: null,
-  };
+class JsonNull extends Component<{}> {
+  static defaultProps = {};
 
   render() {
-    return (
-      <div>
-        {this.props.name ? `"${this.props.name}": ` : ''}
-        null
-      </div>
-    );
+    return <span>null</span>;
   }
 }
 

--- a/src/ui/json/JsonNumber.js
+++ b/src/ui/json/JsonNumber.js
@@ -3,21 +3,14 @@
 import React, { Component } from 'react';
 
 class JsonNumber extends Component<{
-  name: ?string,
   json: number,
 }> {
   static defaultProps = {
-    name: null,
     json: NaN,
   };
 
   render() {
-    return (
-      <div>
-        {this.props.name ? `"${this.props.name}": ` : ''}
-        {this.props.json.toString()}
-      </div>
-    );
+    return <span>{this.props.json.toString()}</span>;
   }
 }
 

--- a/src/ui/json/JsonObject.js
+++ b/src/ui/json/JsonObject.js
@@ -8,41 +8,74 @@ import JsonBoolean from './JsonBoolean';
 import JsonNull from './JsonNull';
 
 class JsonObject extends Component<{
-  name: ?string,
+  depth: number,
   json: {},
 }> {
   static defaultProps = {
-    name: null,
+    depth: 0,
     json: {},
   };
 
   render() {
-    return (
-      <div className="jsonObject">
-        {this.props.name ? `"${this.props.name}": ` : ''}
-        {'{'}
-        {Object.keys(this.props.json).map((key) => {
-          const value = this.props.json[key];
-          switch (typeof value) {
-            case 'object':
-              if (value === null) {
-                return <JsonNull name={key} key={key} />;
-              } else if (Array.isArray(value)) {
-                return <JsonArray json={value} name={key} key={key} />;
-              }
-              return <JsonObject json={value} name={key} key={key} />;
-            case 'number':
-              return <JsonNumber json={value} name={key} key={key} />;
-            case 'string':
-              return <JsonString json={value} name={key} key={key} />;
-            case 'boolean':
-              return <JsonBoolean json={value} name={key} key={key} />;
-            default:
-              throw new Error('Invalid json property');
-          }
+    const currentIndentation = (
+      <React.Fragment>
+        {Array.from(new Array(this.props.depth).keys()).map((_) => {
+          return <React.Fragment>&nbsp; </React.Fragment>;
         })}
+      </React.Fragment>
+    );
+    const nextIndentation = (
+      <React.Fragment>&nbsp; {currentIndentation}</React.Fragment>
+    );
+    return (
+      <span className="jsonObject">
+        {'{'}
+        {Object.keys(this.props.json).length === 0 ? null : (
+          <ul>
+            {Object.keys(this.props.json).map((key) => {
+              const value = this.props.json[key];
+              let jsonContent;
+              switch (typeof value) {
+                case 'object':
+                  if (value === null) {
+                    jsonContent = <JsonNull />;
+                    break;
+                  } else if (Array.isArray(value)) {
+                    jsonContent = (
+                      <JsonArray json={value} depth={this.props.depth + 1} />
+                    );
+                    break;
+                  }
+                  jsonContent = (
+                    <JsonObject json={value} depth={this.props.depth + 1} />
+                  );
+                  break;
+                case 'number':
+                  jsonContent = <JsonNumber json={value} />;
+                  break;
+                case 'string':
+                  jsonContent = <JsonString json={value} />;
+                  break;
+                case 'boolean':
+                  jsonContent = <JsonBoolean json={value} />;
+                  break;
+                default:
+                  throw new Error('Invalid json property');
+              }
+              return (
+                <li key={key}>
+                  {nextIndentation}
+                  {`"${key.replace(/"/g, '\\"')}": `}
+                  {jsonContent}
+                  {','}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        {currentIndentation}
         {'}'}
-      </div>
+      </span>
     );
   }
 }

--- a/src/ui/json/JsonString.js
+++ b/src/ui/json/JsonString.js
@@ -3,22 +3,19 @@
 import React, { Component } from 'react';
 
 class JsonString extends Component<{
-  name: ?string,
   json: string,
 }> {
   static defaultProps = {
-    name: null,
     json: '',
   };
 
   render() {
     return (
-      <div>
-        {this.props.name ? `"${this.props.name}": ` : ''}
+      <span>
         {'"'}
-        {this.props.json}
+        {this.props.json.replace(/"/g, '\\"')}
         {'"'}
-      </div>
+      </span>
     );
   }
 }


### PR DESCRIPTION
In previous version, if you copy any JSON on screen, the text isn't valid JSON. This fixed the issue. JSON is printed out as valid JSON. It can be copied. It can be pasted back to `ConsoleView` to use as POST/PUT request body.

I also made the JSON to use monospace font, so it looks more like code and more comfortable to look at. I didn't use `<pre />` to wrap JSON because I want to enable JSON editing in the future.

<img width="1224" alt="screenshot 2018-06-22 00 57 52" src="https://user-images.githubusercontent.com/112175/41764937-6bd2046a-75b7-11e8-8c1b-0bcc2a746297.png">
