### PR TITLE
Made JSON copiable text valid JSON

### DIFF
--- a/src/ui/json/JsonArray.js
+++ b/src/ui/json/JsonArray.js
@@ -18,21 +18,22 @@ class JsonArray extends Component<{
 
   render() {
     const currentIndentation = (
-      <React.Fragment>
-        {Array.from(new Array(this.props.depth).keys()).map((_) => {
-          return <React.Fragment>&nbsp; </React.Fragment>;
-        })}
-      </React.Fragment>
+      <pre
+        dangerouslySetInnerHTML={{ __html: '  '.repeat(this.props.depth) }}
+      />
     );
     const nextIndentation = (
-      <React.Fragment>&nbsp; {currentIndentation}</React.Fragment>
+      <pre
+        dangerouslySetInnerHTML={{ __html: '  '.repeat(this.props.depth + 1) }}
+      />
     );
+
     return (
       <span className="jsonArray">
         {'['}
         {this.props.json.length === 0 ? null : (
           <ul>
-            {this.props.json.map((value, index) => {
+            {this.props.json.map((value, index, values) => {
               let jsonContent;
               switch (typeof value) {
                 case 'object':
@@ -65,7 +66,7 @@ class JsonArray extends Component<{
                 <li key={index}>
                   {nextIndentation}
                   {jsonContent}
-                  {','}
+                  {index < values.length - 1 ? ',' : null}
                 </li>
               );
             })}

--- a/src/ui/json/JsonEditor.css
+++ b/src/ui/json/JsonEditor.css
@@ -4,3 +4,9 @@
   margin-bottom: 0;
   padding-left: 0;
 }
+
+.jsonObject pre,
+.jsonArray pre {
+  display: inline;
+  font-size: medium;
+}

--- a/src/ui/json/JsonObject.js
+++ b/src/ui/json/JsonObject.js
@@ -18,21 +18,21 @@ class JsonObject extends Component<{
 
   render() {
     const currentIndentation = (
-      <React.Fragment>
-        {Array.from(new Array(this.props.depth).keys()).map((_) => {
-          return <React.Fragment>&nbsp; </React.Fragment>;
-        })}
-      </React.Fragment>
+      <pre
+        dangerouslySetInnerHTML={{ __html: '  '.repeat(this.props.depth) }}
+      />
     );
     const nextIndentation = (
-      <React.Fragment>&nbsp; {currentIndentation}</React.Fragment>
+      <pre
+        dangerouslySetInnerHTML={{ __html: '  '.repeat(this.props.depth + 1) }}
+      />
     );
     return (
       <span className="jsonObject">
         {'{'}
         {Object.keys(this.props.json).length === 0 ? null : (
           <ul>
-            {Object.keys(this.props.json).map((key) => {
+            {Object.keys(this.props.json).map((key, index, keys) => {
               const value = this.props.json[key];
               let jsonContent;
               switch (typeof value) {
@@ -67,7 +67,7 @@ class JsonObject extends Component<{
                   {nextIndentation}
                   {`"${key.replace(/"/g, '\\"')}": `}
                   {jsonContent}
-                  {','}
+                  {index < keys.length - 1 ? ',' : null}
                 </li>
               );
             })}

--- a/src/ui/json/__tests__/JsonArray-test.js
+++ b/src/ui/json/__tests__/JsonArray-test.js
@@ -1,0 +1,126 @@
+import JsonArray from '../JsonArray';
+import React from 'react';
+import { mount } from 'enzyme';
+
+it('should render empty value', () => {
+  const wrapper = mount(<JsonArray json={[]} />);
+  expect(wrapper.text()).toBe('[]');
+});
+
+it('should render value with null', () => {
+  const wrapper = mount(<JsonArray json={[null, null, null]} />);
+  // prettier-ignore
+  expect(wrapper.text()).toBe([
+    '[',
+    '  null,',
+    '  null,',
+    '  null',
+    ']'
+  ].join(''));
+});
+
+it('should render value with boolean', () => {
+  const wrapper = mount(<JsonArray json={[true, false, true]} />);
+  // prettier-ignore
+  expect(wrapper.text()).toBe([
+    '[',
+    '  true,',
+    '  false,',
+    '  true',
+    ']'
+  ].join(''));
+});
+
+it('should render value with number', () => {
+  const wrapper = mount(<JsonArray json={[42, 0, -42]} />);
+  // prettier-ignore
+  expect(wrapper.text()).toBe([
+    '[',
+    '  42,',
+    '  0,',
+    '  -42',
+    ']'
+  ].join(''));
+});
+
+it('should render value with string', () => {
+  const wrapper = mount(
+    <JsonArray json={['Hello, world!', '', 'Let\'s say "yes".']} />,
+  );
+  // prettier-ignore
+  expect(wrapper.text()).toBe([
+    '[',
+    '  "Hello, world!",',
+    '  "",',
+    '  "Let\'s say \\"yes\\"."',
+    ']'
+  ].join(''));
+});
+
+it('should render value with array', () => {
+  const wrapper = mount(<JsonArray json={[[], [42], [[42]]]} />);
+  // prettier-ignore
+  expect(wrapper.text()).toBe([
+    '[',
+    '  [',
+    '  ],',
+    '  [',
+    '    42',
+    '  ],',
+    '  [',
+    '    [',
+    '      42',
+    '    ]',
+    '  ]',
+    ']'
+  ].join(''));
+});
+
+it('should render value with object', () => {
+  const wrapper = mount(
+    <JsonArray json={[{ x: 42, y: 0, z: -42 }, {}, { x: { y: { z: 42 } } }]} />,
+  );
+  // prettier-ignore
+  expect(wrapper.text()).toBe([
+    '[',
+    '  {',
+    '    "x": 42,',
+    '    "y": 0,',
+    '    "z": -42',
+    '  },',
+    '  {',
+    '  },',
+    '  {',
+    '    "x": {',
+    '      "y": {',
+    '        "z": 42',
+    '      }',
+    '    }',
+    '  }',
+    ']'
+  ].join(''));
+});
+
+it('should render value in mixed types', () => {
+  const wrapper = mount(
+    <JsonArray
+      json={[null, true, 42, 'Hello, world!', [false, -42], { value: NaN }]}
+    />,
+  );
+  // prettier-ignore
+  expect(wrapper.text()).toBe([
+    '[',
+    '  null,',
+    '  true,',
+    '  42,',
+    '  "Hello, world!",',
+    '  [',
+    '    false,',
+    '    -42',
+    '  ],',
+    '  {',
+    '    "value": NaN',
+    '  }',
+    ']'
+  ].join(''));
+});

--- a/src/ui/json/__tests__/JsonObject-test.js
+++ b/src/ui/json/__tests__/JsonObject-test.js
@@ -1,0 +1,47 @@
+import JsonObject from '../JsonObject';
+import React from 'react';
+import { mount } from 'enzyme';
+
+it('should render empty value', () => {
+  const wrapper = mount(<JsonObject json={{}} />);
+  expect(wrapper.text()).toBe('{}');
+});
+
+it('should render value in mixed types', () => {
+  const wrapper = mount(
+    <JsonObject
+      json={{
+        a: null,
+        b: true,
+        c: false,
+        d: 42,
+        e: NaN,
+        f: 'Let\'s say "yes".',
+        g: [3.14, 2.22],
+        h: { x: { y: { z: 42 } } },
+      }}
+    />,
+  );
+  // prettier-ignore
+  expect(wrapper.text()).toBe([
+    '{',
+    '  "a": null,',
+    '  "b": true,',
+    '  "c": false,',
+    '  "d": 42,',
+    '  "e": NaN,',
+    '  "f": "Let\'s say \\"yes\\".",',
+    '  "g": [',
+    '    3.14,',
+    '    2.22',
+    '  ],',
+    '  "h": {',
+    '    "x": {',
+    '      "y": {',
+    '        "z": 42',
+    '      }',
+    '    }',
+    '  }',
+    '}'
+  ].join(''));
+});


### PR DESCRIPTION
Two things:

1. Valid JSON text should not have trailing comma. I removed that.
2. Indentation was created by repeating `'&nbsp; '`. There's no problem in product, because the copiable text will not contain `'&nbsp; '`. (It will be converted to space.) However, `&nbsp;` shows up as ASCII code 160 instead of 32 in test. It makes test case writing inconvenient, so I'm changing it real space (ASCII code 32). In order to render a string of repetitive spaces, I switch implementation to `<pre>`.

P.S. Because this PR is based on PR #19, I'm requesting merge into that branch. I'm not sure what will happen if we do merge it.