### PR TITLE
Buildpack experimentation

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
   "addons": [],
   "buildpacks": [
     {
-      "url": "https://github.com/mars/create-react-app-buildpack.git"
+      "url": "https://github.com/CatChen/create-react-app-buildpack.git"
     }
   ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -27,14 +27,17 @@ if (window.location.search) {
   const state = url.searchParams.get('state');
   if (code && state) {
     const settings = Settings.read();
-    const hash = btoa(`${settings.clientId}:${settings.clientSecret}`);
+    const hash =
+      settings.clientId && settings.clientSecret
+        ? btoa(`${settings.clientId}:${settings.clientSecret}`)
+        : null;
     let bridgeId = null;
     let bridgeOAuthProperties;
 
     fetch(`/oauth2/token?code=${code}&grant_type=authorization_code`, {
       method: 'POST',
       headers: {
-        Authorization: `Basic ${hash}`,
+        Authorization: hash ? `Basic ${hash}` : null,
       },
     })
       .then((response) => {
@@ -105,7 +108,7 @@ if (window.location.search) {
               return fetch(`/bridge`, {
                 method: 'POST',
                 body: JSON.stringify({
-                  devicetype: bridgeOAuthProperties.appId,
+                  devicetype: process.env.REACT_APP_OAUTH_APP_ID,
                 }),
                 headers: {
                   Authorization: `Bearer ${bridgeOAuthProperties.accessToken}`,
@@ -136,6 +139,7 @@ if (window.location.search) {
 ReactDOM.render(<App />, document.getElementById('root'));
 registerServiceWorker();
 
+console.log('NODE_ENV', process.env.NODE_ENV);
 window.HueBridge = HueBridge;
 window.HueBridgeList = HueBridgeList;
 window.Settings = Settings;

--- a/src/ui/HueBridgeSelector.js
+++ b/src/ui/HueBridgeSelector.js
@@ -101,9 +101,10 @@ class HueBridgeSelector extends Component {
           className="dropdown-item"
           rel="noopener noreferrer"
           target="_blank"
-          href={`https://api.meethue.com/oauth2/auth?clientid=${
-            this.state.settings.clientId
-          }&appid=${this.state.settings.appId}&deviceid=${
+          href={`https://api.meethue.com/oauth2/auth?clientid=${this.state
+            .settings.clientId ||
+            process.env.REACT_APP_OAUTH_CLIENT_ID}&appid=${this.state.settings
+            .appId || process.env.REACT_APP_OAUTH_APP_ID}&deviceid=${
             this.state.deviceId
           }&response_type=code&state=${window.location.pathname}`}
         >

--- a/static.json
+++ b/static.json
@@ -7,7 +7,7 @@
     "/oauth2": {
       "origin": "https://api.meethue.com/oauth2",
       "headers": {
-        "Authorization": "Basic ${OAUTH_ID_SECRET_HASH}"
+        "Authorization": "Basic ${OAUTH_CLIENT_ID_SECRET_HASH}"
       }
     },
     "/bridge": {

--- a/static.json
+++ b/static.json
@@ -5,7 +5,10 @@
   },
   "proxies": {
     "/oauth2": {
-      "origin": "https://api.meethue.com/oauth2"
+      "origin": "https://api.meethue.com/oauth2",
+      "headers": {
+        "Authorization": "Basic ${OAUTH_ID_SECRET_HASH}"
+      }
     },
     "/bridge": {
       "origin": "https://api.meethue.com/bridge"


### PR DESCRIPTION
This is a big change. Not a lot of files changed inside this repo, but more outside.

Here's what I want to achieve: Set OAuth `app_id`, `client_id`, `client_secret` as environment variables on the server and then nobody needs to set them separately. (Otherwise, nobody would really want to try out this app because nobody would apply for Hue OAuth by themselves.)

The biggest blocker is the OAuth `client_secret` needed for the request to `/oauth2/token`. I can't expose it in JavaScript. If I use typical `REACT_APP_*` environment variable, it will be compiled into JavaScript and expose. I have to keep it on the server side while use it when making the request to `/oauth2/token`.

The way I solved this is to ask Nginx to read the `client_secret` variable from the server directly and append it to the request header, so `client_secret` never leaves the server. It sounds simple but it's not supported in existing Heroku buildpack setup, so I had to change that.

First I added the header config in `static.json`, which is the source file that `heroku-buildpack-static` uses and compiles into Nginx config.  This doesn't do anything, because `heroku-buildpack-static` doesn't recognize this new information yet.

Then I forked `heroku-buildpack-static` and changed that: https://github.com/CatChen/heroku-buildpack-static/commit/a77851a396eb39a23140e4ba1e0839b0a608b808. It can extract the header settings from `static.json`, replace environment variable with real value and put that into Nginx config.

Finally I forked `create-react-app-buildpack`, which is the actual buildpack used by this app. It depends on the official `heroku-buildpack-static` and I pointed that to my fork.

Now I can set the environment variables on Heroku and we don't have to set it inside the Settings dialog. At least, that's for http://hue-explorer.herokuapp.com. (It doesn't work for other Heroku instances of the same source code deployment, because environment variables don't share.)