### PR TITLE
Oauth callback redirection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,118 +21,137 @@ function oauthFailure(url) {
   throw new Error('OAuth failure');
 }
 
+function oauthRedirect(url, code) {
+  const destinationURL = new URL(url);
+  destinationURL.searchParams.append('code', code);
+  destinationURL.searchParams.append('state', url);
+  window.location.href = destinationURL.href;
+  debugger;
+}
+
 if (window.location.search) {
   const url = new URL(window.location.href);
   const code = url.searchParams.get('code');
   const state = url.searchParams.get('state');
   if (code && state) {
-    const settings = Settings.read();
-    const hash =
-      settings.clientId && settings.clientSecret
-        ? btoa(`${settings.clientId}:${settings.clientSecret}`)
-        : null;
-    let bridgeId = null;
-    let bridgeOAuthProperties;
+    const thisURL = new URL(window.location.href);
+    const thatURL = new URL(state);
+    if (
+      thisURL.protocol !== thatURL.protocol ||
+      thisURL.host !== thatURL.host
+    ) {
+      oauthRedirect(state, code);
+    } else {
+      const settings = Settings.read();
+      const hash =
+        settings.clientId && settings.clientSecret
+          ? btoa(`${settings.clientId}:${settings.clientSecret}`)
+          : null;
+      let bridgeId = null;
+      let bridgeOAuthProperties;
 
-    fetch(`/oauth2/token?code=${code}&grant_type=authorization_code`, {
-      method: 'POST',
-      headers: {
-        Authorization: hash ? `Basic ${hash}` : null,
-      },
-    })
-      .then((response) => {
-        return response.json();
+      fetch(`/oauth2/token?code=${code}&grant_type=authorization_code`, {
+        method: 'POST',
+        headers: {
+          Authorization: hash ? `Basic ${hash}` : null,
+        },
       })
-      .then((json) => {
-        console.log(json);
-        if (json.fault) {
-          oauthFailure(state);
-        }
+        .then((response) => {
+          return response.json();
+        })
+        .then((json) => {
+          console.log(json);
+          if (json.fault) {
+            oauthFailure(state);
+          }
 
-        bridgeOAuthProperties = {
-          accessToken: json.access_token,
-          refreshToken: json.refresh_token,
-          tokenType: json.token_type,
-          accessTokenExpiresAt:
-            Date.now() + parseInt(json.access_token_expires_in, 10),
-          refreshTokenExpiresAt:
-            Date.now() + parseInt(json.refresh_token_expires_in, 10),
-        };
-
-        return fetch(`/bridge/0/config`, {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${bridgeOAuthProperties.accessToken}`,
-          },
-        });
-      })
-      .then((response) => {
-        return response.json();
-      })
-      .then((json) => {
-        bridgeId = json.bridgeid;
-        if (!bridgeId) {
-          oauthFailure(state);
-        }
-        HueBridgeList.load();
-        const bridge = HueBridge.getById(bridgeId);
-        if (bridge && bridge.properties.username) {
-          // If the bridge was authorized before, e.g. locally, add remote properties.
-          bridge.properties = {
-            ...bridge.properties,
-            ...bridgeOAuthProperties,
-            remote: true,
+          bridgeOAuthProperties = {
+            accessToken: json.access_token,
+            refreshToken: json.refresh_token,
+            tokenType: json.token_type,
+            accessTokenExpiresAt:
+              Date.now() + parseInt(json.access_token_expires_in, 10),
+            refreshTokenExpiresAt:
+              Date.now() + parseInt(json.refresh_token_expires_in, 10),
           };
-          bridge.store();
-          oauthSuccess(state);
-        } else {
-          // If the bridge was never seen before, authorize through remote API.
-          fetch(`/bridge/0/config`, {
-            method: 'PUT',
-            body: JSON.stringify({
-              linkbutton: true,
-            }),
+
+          return fetch(`/bridge/0/config`, {
+            method: 'GET',
             headers: {
               Authorization: `Bearer ${bridgeOAuthProperties.accessToken}`,
-              'content-type': 'application/json',
             },
-          })
-            .then((response) => {
-              return response.json();
+          });
+        })
+        .then((response) => {
+          return response.json();
+        })
+        .then((json) => {
+          bridgeId = json.bridgeid;
+          if (!bridgeId) {
+            oauthFailure(state);
+          }
+          HueBridgeList.load();
+          const bridge = HueBridge.getById(bridgeId);
+          if (bridge && bridge.properties.username) {
+            // If the bridge was authorized before, e.g. locally, add remote properties.
+            bridge.properties = {
+              ...bridge.properties,
+              ...bridgeOAuthProperties,
+              remote: true,
+            };
+            bridge.store();
+            oauthSuccess(state);
+          } else {
+            // If the bridge was never seen before, authorize through remote API.
+            fetch(`/bridge/0/config`, {
+              method: 'PUT',
+              body: JSON.stringify({
+                linkbutton: true,
+              }),
+              headers: {
+                Authorization: `Bearer ${bridgeOAuthProperties.accessToken}`,
+                'content-type': 'application/json',
+              },
             })
-            .then((json) => {
-              console.log(json);
-              if (!json[0] || !json[0].success) {
-                oauthFailure(state);
-              }
-              return fetch(`/bridge`, {
-                method: 'POST',
-                body: JSON.stringify({
-                  devicetype: process.env.REACT_APP_OAUTH_APP_ID,
-                }),
-                headers: {
-                  Authorization: `Bearer ${bridgeOAuthProperties.accessToken}`,
-                  'content-type': 'application/json',
-                },
+              .then((response) => {
+                return response.json();
+              })
+              .then((json) => {
+                console.log(json);
+                if (!json[0] || !json[0].success) {
+                  oauthFailure(state);
+                }
+                return fetch(`/bridge`, {
+                  method: 'POST',
+                  body: JSON.stringify({
+                    devicetype: process.env.REACT_APP_OAUTH_APP_ID,
+                  }),
+                  headers: {
+                    Authorization: `Bearer ${
+                      bridgeOAuthProperties.accessToken
+                    }`,
+                    'content-type': 'application/json',
+                  },
+                });
+              })
+              .then((response) => {
+                return response.json();
+              })
+              .then((json) => {
+                if (!json[0] || !json[0].success) {
+                  oauthFailure(state);
+                }
+                const bridge = new HueBridge(bridgeId, {
+                  username: json[0].success.username,
+                  remote: true,
+                });
+                bridge.store();
+                HueBridgeList.add(bridgeId);
+                oauthSuccess(state);
               });
-            })
-            .then((response) => {
-              return response.json();
-            })
-            .then((json) => {
-              if (!json[0] || !json[0].success) {
-                oauthFailure(state);
-              }
-              const bridge = new HueBridge(bridgeId, {
-                username: json[0].success.username,
-                remote: true,
-              });
-              bridge.store();
-              HueBridgeList.add(bridgeId);
-              oauthSuccess(state);
-            });
-        }
-      });
+          }
+        });
+    }
   }
 }
 

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -19,3 +19,22 @@ const fetchMock = jest.fn().mockImplementation(() => {
   };
 });
 global.fetch = fetchMock;
+
+const urlMock = jest.fn().mockImplementation(() => {
+  return {
+    searchParams: {
+      append: jest.fn(),
+      delete: jest.fn(),
+      entries: jest.fn(),
+      get: jest.fn(),
+      getAll: jest.fn(),
+      has: jest.fn(),
+      keys: jest.fn(),
+      set: jest.fn(),
+      sort: jest.fn(),
+      toString: jest.fn(),
+      values: jest.fn(),
+    },
+  };
+});
+global.URL = urlMock;

--- a/src/ui/HueBridgeSelector.js
+++ b/src/ui/HueBridgeSelector.js
@@ -67,17 +67,17 @@ class HueBridgeSelector extends Component {
   render() {
     const activeBridgeId = ActiveBridge.get();
     const oauthURL = new URL('https://api.meethue.com/oauth2/auth');
-    oauthURL.searchParams.append(
+    oauthURL.searchParams.set(
       'clientid',
       this.state.settings.clientId || process.env.REACT_APP_OAUTH_CLIENT_ID,
     );
-    oauthURL.searchParams.append(
+    oauthURL.searchParams.set(
       'appid',
       this.state.settings.appId || process.env.REACT_APP_OAUTH_APP_ID,
     );
-    oauthURL.searchParams.append('deviceid', this.state.deviceId);
-    oauthURL.searchParams.append('response_type', 'code');
-    oauthURL.searchParams.append('state', window.location.href);
+    oauthURL.searchParams.set('deviceid', this.state.deviceId);
+    oauthURL.searchParams.set('response_type', 'code');
+    oauthURL.searchParams.set('state', window.location.href);
 
     return (
       <div className="dropdown-menu" aria-labelledby="navbarDropdown">

--- a/src/ui/HueBridgeSelector.js
+++ b/src/ui/HueBridgeSelector.js
@@ -66,6 +66,19 @@ class HueBridgeSelector extends Component {
 
   render() {
     const activeBridgeId = ActiveBridge.get();
+    const oauthURL = new URL('https://api.meethue.com/oauth2/auth');
+    oauthURL.searchParams.append(
+      'clientid',
+      this.state.settings.clientId || process.env.REACT_APP_OAUTH_CLIENT_ID,
+    );
+    oauthURL.searchParams.append(
+      'appid',
+      this.state.settings.appId || process.env.REACT_APP_OAUTH_APP_ID,
+    );
+    oauthURL.searchParams.append('deviceid', this.state.deviceId);
+    oauthURL.searchParams.append('response_type', 'code');
+    oauthURL.searchParams.append('state', window.location.href);
+
     return (
       <div className="dropdown-menu" aria-labelledby="navbarDropdown">
         {this.state.bridges.map((bridge) => {
@@ -101,12 +114,7 @@ class HueBridgeSelector extends Component {
           className="dropdown-item"
           rel="noopener noreferrer"
           target="_blank"
-          href={`https://api.meethue.com/oauth2/auth?clientid=${this.state
-            .settings.clientId ||
-            process.env.REACT_APP_OAUTH_CLIENT_ID}&appid=${this.state.settings
-            .appId || process.env.REACT_APP_OAUTH_APP_ID}&deviceid=${
-            this.state.deviceId
-          }&response_type=code&state=${window.location.pathname}`}
+          href={oauthURL.toString()}
         >
           Add remote bridges
         </a>


### PR DESCRIPTION
Hue OAuth API doesn't allow me to set any callback URL programmatically. The callback URL I set when I created the app is permanent. That means my current app always has a callback URL as `http://hue-explorer.herokuapp.com`. This isn't convenient when I need to test with other domains, because it always goes back to one domain and saves access token in the local storage of that domain.

This PR mitigates that issue by callback redirection. Now I set the `state` param with the full callback URL instead of just a path. When handling the callback, if `state` has a different domain then we would redirect to that domain and let it handle the actual callback. Then that domain will store the access token, and everything would work for that domain.