### PR TITLE
Fixed dropping access token in first OAuth try

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,6 +144,7 @@ if (window.location.search) {
                 const bridge = new HueBridge(bridgeId, {
                   username: json[0].success.username,
                   remote: true,
+                  ...bridgeOAuthProperties,
                 });
                 bridge.store();
                 HueBridgeList.add(bridgeId);


### PR DESCRIPTION
Previously when setting up a new bridge through OAuth, the first time it remembers the bridge metadata but forgets the access token. Then a second OAuth can make it remembering the access token. The reason was I forgot to store access token with other metadata in this branch. Now I'm fixing this bug.