### PR TITLE
Set app.json to inherit environment variables for review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,20 @@
 {
   "name": "hue-explorer",
   "scripts": {},
-  "env": {},
+  "env": {
+    "OAUTH_CLIENT_ID_SECRET_HASH": {
+      "description": "Hash of OAuth client_id and client_secret",
+      "required": true
+    },
+    "REACT_APP_OAUTH_APP_ID": {
+      "description": "OAuth app_id",
+      "required": true
+    },
+    "REACT_APP_OAUTH_CLIENT_ID": {
+      "description": "OAuth client_id",
+      "required": true
+    }
+  },
   "formation": {
     "web": {
       "quantity": 1


### PR DESCRIPTION
After introducing environment variables, review app was broken because they fail to read them:

```
2018-07-08T02:14:00.732737+00:00 heroku[web.1]: State changed from crashed to starting
2018-07-08T02:14:11.713451+00:00 heroku[web.1]: Starting process with command `bin/boot`
2018-07-08T02:14:14.770405+00:00 app[web.1]: Injecting runtime env into /app/build/static/js/main.c5558d23.js (from .profile.d/inject_react_app_env.sh)
2018-07-08T02:14:15.245743+00:00 app[web.1]: Starting log redirection...
2018-07-08T02:14:15.245776+00:00 app[web.1]: Starting nginx...
2018-07-08T02:14:15.277871+00:00 app[web.1]: nginx: [emerg] unknown "oauth_client_id_secret_hash" variable
2018-07-08T02:14:15.277874+00:00 app[web.1]: Process exited unexpectedly: nginx
2018-07-08T02:14:15.281742+00:00 app[web.1]: Going down, terminating child processes...
2018-07-08T02:14:15.389735+00:00 heroku[web.1]: Process exited with status 1
```

Heroku says environment variables can be inherited, but they need to be defined in `app.json` first: https://devcenter.heroku.com/articles/github-integration-review-apps#inheriting-config-vars

This PR does exactly that.