### PR TITLE
Migrated domain to hueexplorer.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 ## Hue Explorer [![Build Status](https://travis-ci.org/shanzhaime/hue-explorer.svg?branch=master)](https://travis-ci.org/shanzhaime/hue-explorer) [![Dependencies](https://david-dm.org/shanzhaime/hue-explorer.svg)](https://david-dm.org/shanzhaime/hue-explorer)
 
-Hue Explorer is a web based tool to help you explore the data in your Philips Hue bridge. These are what you can do with the current version (0.2.0):
+Hue Explorer is a web based tool to help you explore the data in your Philips Hue bridge. These are what you can do with the current version (0.3.0):
 
 1.  Discover and connect to local Hue bridges.
 2.  See all data from the bridge in JSON format.
+3.  Support remote (out of home) control of the bridge.
+4.  Render color values as corresponding colors on screen.
 
 Here are the things I plan for future versions:
 
 1.  Visualize data in a more meaningful way, for example:
-1.  Render color values as corresponding colors on screen.
-1.  Link data between different views, like show light names instead of light ids in a room.
-1.  Enable editing of certain data.
-1.  Support remote (out of home) control of the bridge.
+2.  Link data between different views, like show light names instead of light ids in a room.
+3.  Enable editing of certain data.
 
-If you want to use it without deploying the code, you can visit [hue-explorer.herokuapp.com](http://hue-explorer.herokuapp.com/).
+If you want to use it without deploying the code, you can visit [https://hueexplorer.app/](https://hueexplorer.app/).

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "hue-explorer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
-  "homepage": "http://hue-explorer.herokuapp.com/",
+  "homepage": "https://hueexplorer.app/",
   "proxy": {
     "/(oauth2|bridge)": {
       "target": "https://api.meethue.com",

--- a/static.json
+++ b/static.json
@@ -15,8 +15,11 @@
     }
   },
   "headers": {
-    "/**": {
-      "Access-Control-Allow-Origin": "http://hue-explorer.herokuapp.com"
+    "/oauth2/**": {
+      "Access-Control-Allow-Origin": "https://hueexplorer.app/"
+    },
+    "/bridge/**": {
+      "Access-Control-Allow-Origin": "https://hueexplorer.app/"
     }
   }
 }


### PR DESCRIPTION
I finished setting up hueexplorer.app. Time to move the main domain from hue-explorer.herokuapp.com to hueexplorer.app. (I already changed Hue API app's callback URL to https://hueexplorer.app.)

I also bumped the version number to 0.3.0, because we are moving along the feature list.