### PR TITLE
Fixed empty JSON object/array incorrect containing indentation

### DIFF
--- a/src/ui/json/JsonArray.js
+++ b/src/ui/json/JsonArray.js
@@ -72,7 +72,7 @@ class JsonArray extends Component<{
             })}
           </ul>
         )}
-        {currentIndentation}
+        {this.props.json.length === 0 ? null : currentIndentation}
         {']'}
       </span>
     );

--- a/src/ui/json/JsonObject.js
+++ b/src/ui/json/JsonObject.js
@@ -73,7 +73,7 @@ class JsonObject extends Component<{
             })}
           </ul>
         )}
-        {currentIndentation}
+        {Object.keys(this.props.json).length === 0 ? null : currentIndentation}
         {'}'}
       </span>
     );

--- a/src/ui/json/__tests__/JsonArray-test.js
+++ b/src/ui/json/__tests__/JsonArray-test.js
@@ -62,8 +62,7 @@ it('should render value with array', () => {
   // prettier-ignore
   expect(wrapper.text()).toBe([
     '[',
-    '  [',
-    '  ],',
+    '  [],',
     '  [',
     '    42',
     '  ],',
@@ -88,8 +87,7 @@ it('should render value with object', () => {
     '    "y": 0,',
     '    "z": -42',
     '  },',
-    '  {',
-    '  },',
+    '  {},',
     '  {',
     '    "x": {',
     '      "y": {',

--- a/src/ui/json/__tests__/JsonObject-test.js
+++ b/src/ui/json/__tests__/JsonObject-test.js
@@ -18,7 +18,7 @@ it('should render value in mixed types', () => {
         e: NaN,
         f: 'Let\'s say "yes".',
         g: [3.14, 2.22],
-        h: { x: { y: { z: 42 } } },
+        h: { x: { y: { z: 42, w: {} } } },
       }}
     />,
   );
@@ -38,7 +38,8 @@ it('should render value in mixed types', () => {
     '  "h": {',
     '    "x": {',
     '      "y": {',
-    '        "z": 42',
+    '        "z": 42,',
+    '        "w": {}',
     '      }',
     '    }',
     '  }',


### PR DESCRIPTION
The test cases expected this:

```
{
  "emptyArray": [
  ],
  "emptyObject": {
  }
}
```

Because test cases get result as a string without newline, everything was correct. The actual rendering was this:

```
{
  "emptyArray": [  ],
  "emptyObject": {  }
}
```

When not counting newline, these two look the same to test cases. However, it looks bad to contain indentation inside empty object/array in this way. So I'm removed it in this PR. Now it should render like this:

```
{
  "emptyArray": [],
  "emptyObject": {}
}
```