### PR TITLE
Hid OAuth settings in production

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -176,13 +176,15 @@ class App extends Component {
                     className="dropdown-menu"
                     aria-labelledby="navbarDropdown"
                   >
-                    <NavLink
-                      className="dropdown-item"
-                      activeClassName="active"
-                      to="/settings/oauth"
-                    >
-                      OAuth
-                    </NavLink>
+                    {process.env.NODE_ENV === 'production' ? null : (
+                      <NavLink
+                        className="dropdown-item"
+                        activeClassName="active"
+                        to="/settings/oauth"
+                      >
+                        OAuth
+                      </NavLink>
+                    )}
                     <NavLink
                       className="dropdown-item"
                       activeClassName="active"

--- a/src/ui/SettingsView.js
+++ b/src/ui/SettingsView.js
@@ -72,6 +72,12 @@ class SettingsView extends Component<PropsType, StateType> {
           <React.Fragment>
             <h5 className="card-header">OAuth Settings</h5>
             <div className="card-body">
+              {process.env.NODE_ENV === 'production' ? (
+                <div className="alert alert-danger mb-0" role="alert">
+                  Do <span className="font-weight-bold">NOT</span> override
+                  these settings. Leave them blank.
+                </div>
+              ) : null}
               <div className="form-group">
                 <label htmlFor="appId">App ID</label>
                 <input


### PR DESCRIPTION
People who use Hue Explorer in production should not try to set OAuth app id/secret by themselves. That's why I'm hiding the link into that setting now.

<img width="1249" alt="screenshot 2018-07-22 14 34 17" src="https://user-images.githubusercontent.com/112175/43050372-609b4f9e-8dbc-11e8-8f42-145273576698.png">

If a user still insists on opening that dialog by entering the correct path, it can be open and the dialog will show a red warning message.

<img width="1249" alt="screenshot 2018-07-22 14 34 22" src="https://user-images.githubusercontent.com/112175/43050375-759716c6-8dbc-11e8-8bd0-32f767d6d6bd.png">

I didn't delete this dialog from production, just in case I want to debug something in production.