### PR TITLE
Disabled local bridge connection when using HTTPS

### DIFF
--- a/src/api/ActiveBridge.js
+++ b/src/api/ActiveBridge.js
@@ -11,7 +11,7 @@ function restoreActiveBridge(): void {
   const activeBridgeId = getActiveBridge();
   if (activeBridgeId) {
     const activeBridge = HueBridge.getById(activeBridgeId);
-    if (activeBridge) {
+    if (activeBridge && HueBridge.isLocalSupported) {
       activeBridge.startLocalPing();
     }
   }
@@ -22,14 +22,16 @@ function selectActiveBridge(bridgeId: string): void {
   if (!activeBridge) {
     throw new Error(`Cannot set active bridge: ${bridgeId}`);
   }
-  const previousActiveBridgeId = getActiveBridge();
-  if (previousActiveBridgeId) {
-    const previousActiveBridge = HueBridge.getById(previousActiveBridgeId);
-    if (previousActiveBridge) {
-      previousActiveBridge.stopLocalPing();
+  if (HueBridge.isLocalSupported) {
+    const previousActiveBridgeId = getActiveBridge();
+    if (previousActiveBridgeId) {
+      const previousActiveBridge = HueBridge.getById(previousActiveBridgeId);
+      if (previousActiveBridge) {
+        previousActiveBridge.stopLocalPing();
+      }
     }
+    activeBridge.startLocalPing();
   }
-  activeBridge.startLocalPing();
   storage.write(bridgeId);
 }
 

--- a/src/api/HueBridge.js
+++ b/src/api/HueBridge.js
@@ -7,6 +7,7 @@ const STORAGE_NAME_PREFIX = 'bridge:';
 const STORAGE_VERSION = 2;
 
 const bridgePool = new Map();
+const isLocalSupported = window.location.protocol === 'http:';
 
 type PropertiesType = {
   username?: string,
@@ -251,6 +252,13 @@ class HueBridge {
       return null;
     }
     return bridge;
+  }
+
+  // Local connection isn't support when the web page is served over HTTPS,
+  // because Hue Bridge's own server doesn't serve HTTPS with valid certificate.
+  // This readonly static property provides a cached value for that purpose.
+  static get isLocalSupported(): boolean {
+    return isLocalSupported;
   }
 }
 

--- a/src/api/__tests__/ActiveBridge-test.js
+++ b/src/api/__tests__/ActiveBridge-test.js
@@ -22,6 +22,8 @@ HueBridge.getById = jest.fn().mockImplementation((id) => {
   }
 });
 
+HueBridge.isLocalSupported = true;
+
 beforeEach(() => {
   let storedId = null;
   Storage.mock.instances[0].write = jest.fn().mockImplementation((id) => {

--- a/src/ui/HueBridgeSelector.js
+++ b/src/ui/HueBridgeSelector.js
@@ -90,11 +90,15 @@ class HueBridgeSelector extends Component {
           const localName =
             bridge.properties.host +
             (hidePort ? '' : `:${bridge.properties.port}`);
+          const isUnreachable =
+            !bridge.properties.remote && !HueBridge.isLocalSupported;
+          const isActive = bridge.properties.id === activeBridgeId;
           return (
             <button
               className={
                 'dropdown-item' +
-                (bridge.properties.id === activeBridgeId ? ' active' : '')
+                (isUnreachable ? ' disabled' : '') +
+                (isActive ? ' active' : '')
               }
               value={bridge.properties.id}
               key={bridge.properties.id}


### PR DESCRIPTION
I'm disabling local connection when the web page is served through HTTPS (e.g. https://hueexplorer.app), because of the "mixed content" issue -- certain browsers refuse to call Hue's HTTP API from an HTTPS page. However, calling HTTPS API isn't possible because Hue Bridge's web server doesn't serve HTTPS with valid certificate. (It's less of a problem if I'm writing a native app, in which I can choose to tolerate invalid certificate.)

What's being disabled:

* Local ping -- a request that is sent every 30 seconds to check if the bridge is reachable in the same LAN.
* Local bridge selection -- bridge without remote connection is shown as disabled in bridge list.