### PR TITLE
Updated flow-bin to 0.79.1

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,10 +8,3 @@
 [lints]
 
 [options]
-
-[strict]
-nonstrict-import
-unclear-type
-unsafe-getters-setters
-untyped-import
-untyped-type-import

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "codecov": "^3.0.4",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
-    "flow-bin": "^0.77.0",
+    "flow-bin": "^0.79.1",
     "husky": "^0.14.3",
     "prettier": "^1.13.7",
     "pretty-quick": "^1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2903,9 +2903,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.77.0:
-  version "0.77.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.77.0.tgz#4e5c93929f289a0c28e08fb361a9734944a11297"
+flow-bin@^0.79.1:
+  version "0.79.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.79.1.tgz#01c9f427baa6556753fa878c192d42e1ecb764b6"
 
 follow-redirects@^1.0.0:
   version "1.4.1"


### PR DESCRIPTION
I'm also removing the `[strict]` section from `.flowconfig` file, because it's no longer mentioned in [current documentation](https://flow.org/en/docs/config/). However, it's still in effect, probably for backward compatibility.

That backward compatibility created problem for PR #40, because of the `unsafe-getters-setters` rule in that section. The rule was also removed, but it's still in effect if it's used. The rule triggers this error for #40:

```
Getters and setters can have side effects and are unsafe. (unsafe-getters-setters)

     257│   // Local connection isn't support when the web page is served over HTTPS,
     258│   // because Hue Bridge's own server doesn't serve HTTPS with valid certificate.
     259│   // This readonly static property provides a cached value for that purpose.
     260│   static get isLocalSupported(): boolean {
     261│     return isLocalSupported;
     262│   }
     263│ }
     264│
     265│ export default HueBridge;
```

By removing this section, #40 no longer reports error in flow.