### PR TITLE
Component refactoring

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ import SettingsView from './ui/SettingsView';
 import HueBridgeSelector from './ui/HueBridgeSelector';
 import ActiveBridge from './api/ActiveBridge';
 import React, { Component } from 'react';
-import { BrowserRouter, NavLink, Route } from 'react-router-dom';
+import { BrowserRouter, NavLink, Route, Switch } from 'react-router-dom';
 
 class App extends Component {
   onBridgeAuthorizationFailure() {
@@ -202,17 +202,19 @@ class App extends Component {
             </div>
           </nav>
           <div className="container-fluid">
-            <Route path="/lights/:id" component={LightsView} />
-            <Route path="/groups/:id" component={GroupsView} />
-            <Route path="/schedules/:id" component={SchedulesView} />
-            <Route path="/scenes/:id" component={ScenesView} />
-            <Route path="/sensors/:id" component={SensorsView} />
-            <Route path="/rules/:id" component={RulesView} />
-            <Route path="/configuration/:id" component={ConfigurationView} />
-            <Route path="/resourcelinks/:id" component={ResourceLinksView} />
-            <Route path="/capabilities/:id" component={CapabilitiesView} />
-            <Route path="/console/:id" component={ConsoleView} />
-            <Route path="/settings/:dialog" component={SettingsView} />
+            <Switch>
+              <Route path="/lights/:id" component={LightsView} />
+              <Route path="/groups/:id" component={GroupsView} />
+              <Route path="/schedules/:id" component={SchedulesView} />
+              <Route path="/scenes/:id" component={ScenesView} />
+              <Route path="/sensors/:id" component={SensorsView} />
+              <Route path="/rules/:id" component={RulesView} />
+              <Route path="/configuration/:id" component={ConfigurationView} />
+              <Route path="/resourcelinks/:id" component={ResourceLinksView} />
+              <Route path="/capabilities/:id" component={CapabilitiesView} />
+              <Route path="/console/:id" component={ConsoleView} />
+              <Route path="/settings/:dialog" component={SettingsView} />
+            </Switch>
           </div>
         </div>
       </BrowserRouter>

--- a/src/ui/GroupsView.js
+++ b/src/ui/GroupsView.js
@@ -1,6 +1,5 @@
-import CenterCard from './CenterCard';
+import LoadingCard from './LoadingCard';
 import Group from './Group';
-import LoadingIndicator from './LoadingIndicator';
 import HueBridge from '../api/HueBridge';
 import HueBridgeList from '../api/HueBridgeList';
 import React, { Component } from 'react';
@@ -56,14 +55,7 @@ class GroupsView extends Component {
 
   render() {
     if (this.state.loading) {
-      return (
-        <CenterCard>
-          <h5 className="card-header">Loading...</h5>
-          <div className="card-body">
-            <LoadingIndicator />
-          </div>
-        </CenterCard>
-      );
+      return <LoadingCard />;
     } else if (
       this.state.json === null ||
       Object.keys(this.state.json).length === 0

--- a/src/ui/LightsView.js
+++ b/src/ui/LightsView.js
@@ -1,5 +1,4 @@
-import CenterCard from './CenterCard';
-import LoadingIndicator from './LoadingIndicator';
+import LoadingCard from './LoadingCard';
 import Light from './Light';
 import HueBridge from '../api/HueBridge';
 import HueBridgeList from '../api/HueBridgeList';
@@ -51,14 +50,7 @@ class LightsView extends Component {
 
   render() {
     if (this.state.loading) {
-      return (
-        <CenterCard>
-          <h5 className="card-header">Loading...</h5>
-          <div className="card-body">
-            <LoadingIndicator />
-          </div>
-        </CenterCard>
-      );
+      return <LoadingCard />;
     } else if (
       this.state.json === null ||
       Object.keys(this.state.json).length === 0

--- a/src/ui/LoadingCard.js
+++ b/src/ui/LoadingCard.js
@@ -1,0 +1,20 @@
+// @flow strict
+
+import CenterCard from './CenterCard';
+import LoadingIndicator from './LoadingIndicator';
+import React, { PureComponent } from 'react';
+
+class LoadingCard extends PureComponent<{}> {
+  render() {
+    return (
+      <CenterCard>
+        <h5 className="card-header">Loading...</h5>
+        <div className="card-body">
+          <LoadingIndicator />
+        </div>
+      </CenterCard>
+    );
+  }
+}
+
+export default LoadingCard;

--- a/src/ui/LoadingIndicator.js
+++ b/src/ui/LoadingIndicator.js
@@ -1,8 +1,8 @@
 // @flow strict
 
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 
-class LoadingIndicator extends Component<{}> {
+class LoadingIndicator extends PureComponent<{}> {
   render() {
     return (
       <div className="progress">

--- a/src/ui/SchedulesView.js
+++ b/src/ui/SchedulesView.js
@@ -1,5 +1,4 @@
-import CenterCard from './CenterCard';
-import LoadingIndicator from './LoadingIndicator';
+import LoadingCard from './LoadingCard';
 import Schedule from './Schedule';
 import HueBridge from '../api/HueBridge';
 import HueBridgeList from '../api/HueBridgeList';
@@ -51,14 +50,7 @@ class SchedulesView extends Component {
 
   render() {
     if (this.state.loading) {
-      return (
-        <CenterCard>
-          <h5 className="card-header">Loading...</h5>
-          <div className="card-body">
-            <LoadingIndicator />
-          </div>
-        </CenterCard>
-      );
+      return <LoadingCard />;
     } else if (
       this.state.json === null ||
       Object.keys(this.state.json).length === 0


### PR DESCRIPTION
When I made this simple refactoring, it was intended for code split (#44). However, after checking the size change of code split, it doesn't make sense to do so and I abandoned that.

What's remaining in this PR is still good:

1. `<Route>` is wrapped in `<Switch>`. That's the correct way to use mutually exclusive routes. At any time, only the first matching route will be rendered. Not all matching routes get rendered. (This doesn't happy for now, but it's good to have a safeguard.)
2. `<LoadingCard>` consolidated some code. It's a `PureComponent` so in theory it's faster. (I don't expect observable performance change though.)