### PR TITLE
Code split by route

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "popper.js": "^1.14.3",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
+    "react-loadable": "^5.5.0",
     "react-router-dom": "^4.3.1",
     "react-scripts": "1.1.4",
     "uuid": "^3.3.2"

--- a/src/App.js
+++ b/src/App.js
@@ -1,17 +1,8 @@
-import LightsView from './ui/LightsView';
-import GroupsView from './ui/GroupsView';
-import SchedulesView from './ui/SchedulesView';
-import ScenesView from './ui/ScenesView';
-import SensorsView from './ui/SensorsView';
-import RulesView from './ui/RulesView';
-import ConfigurationView from './ui/ConfigurationView';
-import ResourceLinksView from './ui/ResourceLinksView';
-import CapabilitiesView from './ui/CapabilitiesView';
-import ConsoleView from './ui/ConsoleView';
-import SettingsView from './ui/SettingsView';
 import HueBridgeSelector from './ui/HueBridgeSelector';
+import LoadingCard from './ui/LoadingCard';
 import ActiveBridge from './api/ActiveBridge';
 import React, { Component } from 'react';
+import Loadable from 'react-loadable';
 import { BrowserRouter, NavLink, Route, Switch } from 'react-router-dom';
 
 class App extends Component {
@@ -203,17 +194,83 @@ class App extends Component {
           </nav>
           <div className="container-fluid">
             <Switch>
-              <Route path="/lights/:id" component={LightsView} />
-              <Route path="/groups/:id" component={GroupsView} />
-              <Route path="/schedules/:id" component={SchedulesView} />
-              <Route path="/scenes/:id" component={ScenesView} />
-              <Route path="/sensors/:id" component={SensorsView} />
-              <Route path="/rules/:id" component={RulesView} />
-              <Route path="/configuration/:id" component={ConfigurationView} />
-              <Route path="/resourcelinks/:id" component={ResourceLinksView} />
-              <Route path="/capabilities/:id" component={CapabilitiesView} />
-              <Route path="/console/:id" component={ConsoleView} />
-              <Route path="/settings/:dialog" component={SettingsView} />
+              <Route
+                path="/lights/:id"
+                component={Loadable({
+                  loader: () => import('./ui/LightsView'),
+                  loading: LoadingCard,
+                })}
+              />
+              <Route
+                path="/groups/:id"
+                component={Loadable({
+                  loader: () => import('./ui/GroupsView'),
+                  loading: LoadingCard,
+                })}
+              />
+              <Route
+                path="/schedules/:id"
+                component={Loadable({
+                  loader: () => import('./ui/SchedulesView'),
+                  loading: LoadingCard,
+                })}
+              />
+              <Route
+                path="/scenes/:id"
+                component={Loadable({
+                  loader: () => import('./ui/ScenesView'),
+                  loading: LoadingCard,
+                })}
+              />
+              <Route
+                path="/sensors/:id"
+                component={Loadable({
+                  loader: () => import('./ui/SensorsView'),
+                  loading: LoadingCard,
+                })}
+              />
+              <Route
+                path="/rules/:id"
+                component={Loadable({
+                  loader: () => import('./ui/RulesView'),
+                  loading: LoadingCard,
+                })}
+              />
+              <Route
+                path="/configuration/:id"
+                component={Loadable({
+                  loader: () => import('./ui/ConfigurationView'),
+                  loading: LoadingCard,
+                })}
+              />
+              <Route
+                path="/resourcelinks/:id"
+                component={Loadable({
+                  loader: () => import('./ui/ResourceLinksView'),
+                  loading: LoadingCard,
+                })}
+              />
+              <Route
+                path="/capabilities/:id"
+                component={Loadable({
+                  loader: () => import('./ui/CapabilitiesView'),
+                  loading: LoadingCard,
+                })}
+              />
+              <Route
+                path="/console/:id"
+                component={Loadable({
+                  loader: () => import('./ui/ConsoleView'),
+                  loading: LoadingCard,
+                })}
+              />
+              <Route
+                path="/settings/:dialog"
+                component={Loadable({
+                  loader: () => import('./ui/SettingsView'),
+                  loading: LoadingCard,
+                })}
+              />
             </Switch>
           </div>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5678,18 +5678,18 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.0, prop-types@^15.6.1:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 prop-types@^15.5.10, prop-types@^15.6.0:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
     fbjs "^0.8.16"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
-prop-types@^15.6.1:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
-  dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
@@ -5859,6 +5859,12 @@ react-error-overlay@^4.0.0:
 react-is@^16.4.1:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
+
+react-loadable@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/react-loadable/-/react-loadable-5.5.0.tgz#582251679d3da86c32aae2c8e689c59f1196d8c4"
+  dependencies:
+    prop-types "^15.5.0"
 
 react-reconciler@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION
The implementation is simple. I'm following [this guide](https://reactjs.org/docs/code-splitting.html#route-based-code-splitting). However, this isn't worth pursuing, because the file sizes don't make sense.

Before code splitting:

```
  108.66 KB  build/static/js/main.eb29535e.js
  21.11 KB   build/static/css/main.9318d25f.css
```

After code splitting:

```
  107.37 KB (-1.29 KB)  build/static/js/main.f2be909f.js
  20.93 KB (-181 B)     build/static/css/main.b9f2dcd5.css
  4.59 KB               build/static/js/0.250d00b6.chunk.js
  4.16 KB               build/static/js/1.f3e41bc2.chunk.js
  2.88 KB               build/static/js/7.c984d0e5.chunk.js
  2.59 KB               build/static/js/2.37ea1a23.chunk.js
  2.14 KB               build/static/js/9.48a811ca.chunk.js
  2.14 KB               build/static/js/6.3a040de5.chunk.js
  2.13 KB               build/static/js/5.060efbde.chunk.js
  2.13 KB               build/static/js/4.6f5034c8.chunk.js
  2.13 KB               build/static/js/3.5fccccf0.chunk.js
  2.13 KB               build/static/js/8.95a8efa7.chunk.js
  1.25 KB               build/static/js/10.239cf225.chunk.js
```

The main bundle doesn't get much smaller. All the routes' chunks are too big. It's better to stay in the old way for now. I will reconsider this one certain route's dependencies are too big.