### PR TITLE
Connection display type fix

### DIFF
--- a/src/ui/HueBridgeSelector.js
+++ b/src/ui/HueBridgeSelector.js
@@ -105,11 +105,11 @@ class HueBridgeSelector extends Component {
               onClick={this.onBridgeClick.bind(this)}
             >
               {bridge.properties.local ? localName : 'Remote Bridge'} ({bridge
-                .properties.local && bridge.state.localReachable
-                ? bridge.properties.username
+                .properties.username
+                ? bridge.properties.local && bridge.state.localReachable
                   ? 'local connection'
-                  : 'local discovery'
-                : 'remote connection'})
+                  : 'remote connection'
+                : 'local discovery'})
             </button>
           );
         })}


### PR DESCRIPTION
I found a bug that locally discover (but not yet authorized) Bridge is shown as "remote connection" in the Bridge list. After fixing it, it should correctly display as "local discovery" now. Screenshot below is after the fix.

<img width="1168" alt="screenshot 2018-10-21 10 11 52" src="https://user-images.githubusercontent.com/112175/47269962-c1f8b200-d519-11e8-9bcc-6fc975b1eb93.png">
