### PR TITLE
Migrated husky hooks from 0.1.4 to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,12 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "flow": "flow",
-    "precommit": "pretty-quick --staged",
     "eject": "react-scripts eject"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
   },
   "devDependencies": {
     "codecov": "^3.1.0",


### PR DESCRIPTION
Husky changed its [hook declaration format](https://github.com/typicode/husky#upgrading-from-014) since 1.0.0, but I didn't notice when upgrading the dependency. Let's fix this.