### PR TITLE
Separated browserlist for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,16 @@
     "prettier": "^1.17.1",
     "pretty-quick": "^1.11.0"
   },
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie <= 11",
-    "not op_mini all"
-  ]
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
 }


### PR DESCRIPTION
Following the CRN 2.x to 3.0 migration guide, I can create separate browserlist for development environment. That means we don't need to transpile ES6+ down to ES5 in development environment, but we will continue to do that for production environment.

https://github.com/facebook/create-react-app/blob/master/CHANGELOG.md#browserslist-support-in-babelpreset-env