### PR TITLE
Set up Mergify to approve Dependabot pull requests

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,7 @@ pull_request_rules:
     conditions:
       - author=dependabot-preview[bot]
       - '#approved-reviews-by>=1'
-      - 'status-success=LGTM analysis: JavaScript'
+      - 'status-failure!=LGTM analysis: JavaScript'
       - status-success=continuous-integration/travis-ci/pr
       - status-success=codecov/patch
     actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,3 +9,4 @@ pull_request_rules:
     actions:
       merge:
         method: squash
+      delete_head_branch:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,11 @@
+pull_request_rules:
+  - name: automatic merge for Dependabot pull requests
+    conditions:
+      - author=dependabot-preview[bot]
+      - '#approved-reviews-by>=1'
+      - 'status-success=LGTM analysis: JavaScript'
+      - status-success=continuous-integration/travis-ci/pr
+      - status-success=codecov/patch
+    actions:
+      merge:
+        method: squash


### PR DESCRIPTION
The Mergify bot can merge a pull request from Dependabot bot after it's approved, so we will no longer need to merge manually.

Before: When Dependabot opens a new pull request, I need to approve it and ask the bot to merge (or trigger merge manually).

After: When Dependabot opens a new pull request, I (or any of us) only need to approve it. Mergify will merge and then delete the branch.

P.S. Here's the quick document to Mergify config: https://doc.mergify.io/getting-started.html#configuration