### PR TITLE
Switched Travis to Node LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 install:
   - yarn install
 node_js:
-  - stable
+  - lts/*
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
Travis started reporting errors. I think it's because Travis is using Node stable which is now v13 instead of v12 and something doesn't work at v13. Let's switch back to v12 by using LTS.